### PR TITLE
Parameterise -t test flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 .DS_Store
 __pycache__/
+data/
+output/

--- a/bin/analysis_submission.py
+++ b/bin/analysis_submission.py
@@ -32,8 +32,13 @@ def get_args():
     parser.add_argument('-au', '--analysis_username', help='Valid Webin submission account ID (e.g. Webin-XXXXX) used to carry out the submission', type=str, required=True)
     parser.add_argument('-ap', '--analysis_password', help='Password for Webin submission account', type=str, required=True)
     parser.add_argument('-o', '--output_location', help='A parent directory to pull configuration file and store outputs.', type=str, required=False)
-    parser.add_argument('-t', '--test', help='Specify whether to use ENA test server for submission', action='store_true')
+    parser.add_argument('-t', '--test', help='Specify whether to use ENA test server for submission. When using this parameter, specify true/T/t.', choices=['true', 'T', 't'], required=False)
     args = parser.parse_args()
+
+    if args.test in ['true', 'T', 't']:
+        args.test = True
+    else:
+        args.test = False
     return args
 
 


### PR DESCRIPTION
This minor change alters the test argument (-t flag). Now, users must provide a 'true' value with the -t (--test) flag, in order to specify usage of test Webin. Values accepted are: true, T or t.

The parameter is optional, so if left out, the default is that users wish to use prod Webin, thereby rendering args.test as False. If the flag is specified, users must choose out of the accepted values, otherwise an error is presented.